### PR TITLE
Kbuild: fix kallsyms failure when building with GCC LTO for arm64

### DIFF
--- a/scripts/kallsyms.c
+++ b/scripts/kallsyms.c
@@ -114,13 +114,15 @@ static int check_symbol_range(const char *sym, unsigned long long addr,
 static int read_symbol(FILE *in, struct sym_entry *s)
 {
 	char str[500];
+	char buf[LINE_MAX];
 	char *sym, stype;
 	int rc;
 
-	rc = fscanf(in, "%llx %c %499s\n", &s->addr, &stype, str);
-	if (rc != 3) {
-		if (rc != EOF && fgets(str, 500, in) == NULL)
-			fprintf(stderr, "Read error or end of file.\n");
+	if (fgets(buf, sizeof(buf), in) == NULL) {
+		return -1;
+	}
+	rc = sscanf(buf, "%llx %c %499s\n", &s->addr, &stype, str);
+	if (rc < 3) {
 		return -1;
 	}
 	if (strlen(str) > KSYM_NAME_LEN) {
@@ -147,18 +149,18 @@ static int read_symbol(FILE *in, struct sym_entry *s)
 		if (strcmp(sym, "__kernel_syscall_via_break") &&
 		    strcmp(sym, "__kernel_syscall_via_epc") &&
 		    strcmp(sym, "__kernel_sigtramp") &&
-		    strcmp(sym, "__gp"))
+		    strcmp(sym, "__gp")){
 			return -1;
+                    }
 
 	}
-	else if (toupper(stype) == 'U' ||
-		 is_arm_mapping_symbol(sym))
+	else if (toupper(stype) == 'U')
 		return -1;
 	/* exclude also MIPS ELF local symbols ($L123 instead of .L123) */
 	else if (str[0] == '$')
 		return -1;
 	/* exclude debugging symbols */
-	else if (stype == 'N' || stype == 'n')
+	else if (toupper(stype) == 'N')
 		return -1;
 	/* exclude s390 kasan local symbols */
 	else if (!strncmp(sym, ".LASANPC", 8))
@@ -180,7 +182,8 @@ static int read_symbol(FILE *in, struct sym_entry *s)
 
 	/* Record if we've found __per_cpu_start/end. */
 	check_symbol_range(sym, s->addr, &percpu_range, 1);
-
+	if (toupper(stype) == 'W' && strstr(sym, ".c") != NULL)
+		return -1;
 	return 0;
 }
 

--- a/scripts/link-vmlinux.sh
+++ b/scripts/link-vmlinux.sh
@@ -229,7 +229,7 @@ kallsyms()
 
 	local afile="`basename ${2} .o`.S"
 
-	${NM} -n ${1} | scripts/kallsyms ${kallsymopt} > ${afile}
+	${NM} -n ${1} 2>/dev/null | scripts/kallsyms ${kallsymopt} > ${afile}
 	${CC} ${aflags} -c -o ${2} ${afile}
 }
 


### PR DESCRIPTION
Fix error "kallsyms failure: relative symbol value 0xffffff8008080000 out of range in relative mode"

Signed-off-by: chiru2000 <chiranthangadi123@gmail.com>